### PR TITLE
feat: Revised Usage of Remote Parameter Fetcher

### DIFF
--- a/packages/flutterfire_remote_parameter_fetcher/example/lib/main.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/example/lib/main.dart
@@ -38,7 +38,9 @@ class _MainAppState extends State<MainApp> {
       'int_parameter',
       onConfigUpdated: (value) {
         debugPrint('remoteParameter value changed: $value');
-        _intParameterValue = value;
+        setState(() {
+          _intParameterValue = value;
+        });
       },
     );
     _intParameterValue = _intRemoteParameter.value;

--- a/packages/flutterfire_remote_parameter_fetcher/example/lib/main.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/example/lib/main.dart
@@ -27,26 +27,26 @@ class MainApp extends StatefulWidget {
 class _MainAppState extends State<MainApp> {
   late final rpf = widget.rpf;
 
-  late final _intRemoteParameter = rpf.getIntParameter('int_parameter');
+  late RemoteParameter<int> _intRemoteParameter;
 
   late int _intParameterValue;
-
-  void listen(int value) {
-    debugPrint('remoteParameter value changed: $value');
-    _intParameterValue = value;
-  }
 
   @override
   void initState() {
     super.initState();
+    _intRemoteParameter = rpf.getIntParameter(
+      'int_parameter',
+      onConfigUpdated: (value) {
+        debugPrint('remoteParameter value changed: $value');
+        _intParameterValue = value;
+      },
+    );
     _intParameterValue = _intRemoteParameter.value;
-    _intRemoteParameter.addListener(listen);
   }
 
   @override
-  void dispose() {
-    // TODO(riscait): adding
-    // remoteParameter.removeListener(listen);
+  Future<void> dispose() async {
+    await _intRemoteParameter.dispose();
     super.dispose();
   }
 
@@ -57,19 +57,8 @@ class _MainAppState extends State<MainApp> {
         appBar: AppBar(title: const Text('FlutterFireRemoteParameterFetcher')),
         body: Padding(
           padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text('RemoteParameter value: $_intParameterValue'),
-              const SizedBox(height: 16),
-              FilledButton(
-                onPressed: () async {
-                  await _intRemoteParameter.activateAndRefetch();
-                },
-                child: const Text('Activate and refetch'),
-              ),
-            ],
+          child: Center(
+            child: Text('RemoteParameter value: $_intParameterValue'),
           ),
         ),
       ),

--- a/packages/flutterfire_remote_parameter_fetcher/lib/remote_parameter_fetcher.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/lib/remote_parameter_fetcher.dart
@@ -1,4 +1,5 @@
 /// Remote Parameter Fetcher
 library remote_parameter_fetcher;
 
+export '../src/remote_parameter.dart';
 export '../src/remote_parameter_fetcher.dart';

--- a/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter.dart
@@ -5,54 +5,19 @@ import 'dart:async';
 class RemoteParameter<T> {
   RemoteParameter({
     required T value,
-    required this.onConfigUpdated,
-    required this.activateAndRefetch,
-  }) : _value = value;
+    required StreamSubscription<void> subscription,
+  })  : _value = value,
+        _subscription = subscription;
 
-  /// A Stream of updated parameter information.
-  Stream<void> onConfigUpdated;
-
-  /// A function that will activate the fetched config and refetch the value.
-  /// This is useful for when you want to force a refetch of the value.
-  final Future<T> Function() activateAndRefetch;
+  /// The subscription to the stream of updated parameter information.
+  final StreamSubscription<void> _subscription;
 
   /// The current value of the parameter.
   T get value => _value;
-  T _value;
+  final T _value;
 
-  final List<void Function(T value)> _listeners = [];
-
-  late StreamSubscription<void> _subscription;
-
-  /// Add a listener to be notified when the value changes.
-  /// Executed when the remote value is updated.
-  void addListener(void Function(T value) listener) {
-    _listeners.add(listener);
-
-    if (_listeners.length == 1) {
-      // When the listener is added for the first time,
-      // monitor the onConfigUpdated stream.
-      _subscription = onConfigUpdated.listen((_) async {
-        _value = await activateAndRefetch();
-        _notifyListeners();
-      });
-    }
-  }
-
-  /// Remove a listener.
-  Future<void> removeListener(void Function(T value) listener) async {
-    _listeners.remove(listener);
-
-    if (_listeners.isEmpty) {
-      // When the last listener is removed,
-      // cancel the subscription to the onConfigUpdated stream.
-      await _subscription.cancel();
-    }
-  }
-
-  void _notifyListeners() {
-    for (final listener in _listeners) {
-      listener(_value);
-    }
+  /// Closes the [RemoteParameter].
+  Future<void> dispose() async {
+    await _subscription.cancel();
   }
 }

--- a/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
@@ -5,6 +5,8 @@ import 'package:meta/meta.dart';
 
 import 'remote_parameter.dart';
 
+typedef ValueChanged<T> = void Function(T value);
+
 /// A class that wraps Remote Config.
 /// Its role is to "fetch the configured parameters from remote and provide
 /// them".
@@ -57,6 +59,11 @@ class RemoteParameterFetcher {
   @visibleForTesting
   late final Stream<RemoteConfigUpdate> onConfigUpdated = _rc.onConfigUpdated;
 
+  /// Filter the Stream of updated parameter information by key.
+  Stream<RemoteConfigUpdate> filteredOnConfigUpdated(String key) {
+    return onConfigUpdated.where((config) => config.updatedKeys.contains(key));
+  }
+
   @visibleForTesting
   String getString(String key) {
     final value = _rc.getString(key);
@@ -107,103 +114,101 @@ class RemoteParameterFetcher {
   }
 
   /// Returns a [RemoteParameter] of type [String].
-  RemoteParameter<String> getStringParameter(String key) {
+  RemoteParameter<String> getStringParameter(
+    String key, {
+    required ValueChanged<String> onConfigUpdated,
+  }) {
     return RemoteParameter<String>(
       value: getString(key),
-      onConfigUpdated: onConfigUpdated.where(
-        (config) => config.updatedKeys.contains(key),
-      ),
-      activateAndRefetch: () async {
+      subscription: filteredOnConfigUpdated(key).listen((event) async {
         await activate();
-        return getString(key);
-      },
+        onConfigUpdated(getString(key));
+      }),
     );
   }
 
   /// Returns a [RemoteParameter] of type [int].
-  RemoteParameter<int> getIntParameter(String key) {
+  RemoteParameter<int> getIntParameter(
+    String key, {
+    required ValueChanged<int> onConfigUpdated,
+  }) {
     return RemoteParameter<int>(
       value: getInt(key),
-      onConfigUpdated: onConfigUpdated.where(
-        (config) => config.updatedKeys.contains(key),
-      ),
-      activateAndRefetch: () async {
+      subscription: filteredOnConfigUpdated(key).listen((event) async {
         await activate();
-        return getInt(key);
-      },
+        onConfigUpdated(getInt(key));
+      }),
     );
   }
 
   /// Returns a [RemoteParameter] of type [double].
-  RemoteParameter<double> getDoubleParameter(String key) {
+  RemoteParameter<double> getDoubleParameter(
+    String key, {
+    required ValueChanged<double> onConfigUpdated,
+  }) {
     return RemoteParameter<double>(
       value: getDouble(key),
-      onConfigUpdated: onConfigUpdated.where(
-        (config) => config.updatedKeys.contains(key),
-      ),
-      activateAndRefetch: () async {
+      subscription: filteredOnConfigUpdated(key).listen((event) async {
         await activate();
-        return getDouble(key);
-      },
+        onConfigUpdated(getDouble(key));
+      }),
     );
   }
 
   /// Returns a [RemoteParameter] of type [bool].
-  RemoteParameter<bool> getBoolParameter(String key) {
+  RemoteParameter<bool> getBoolParameter(
+    String key, {
+    required ValueChanged<bool> onConfigUpdated,
+  }) {
     return RemoteParameter<bool>(
       value: getBool(key),
-      onConfigUpdated: onConfigUpdated.where(
-        (config) => config.updatedKeys.contains(key),
-      ),
-      activateAndRefetch: () async {
+      subscription: filteredOnConfigUpdated(key).listen((event) async {
         await activate();
-        return getBool(key);
-      },
+        onConfigUpdated(getBool(key));
+      }),
     );
   }
 
   /// Returns a [RemoteParameter] of type [Map].
-  RemoteParameter<Map<String, Object?>> getJsonParameter(String key) {
+  RemoteParameter<Map<String, Object?>> getJsonParameter(
+    String key, {
+    required void Function(Map<String, Object?> value) onConfigUpdated,
+  }) {
     return RemoteParameter<Map<String, Object?>>(
       value: getJson(key),
-      onConfigUpdated: onConfigUpdated.where(
-        (config) => config.updatedKeys.contains(key),
-      ),
-      activateAndRefetch: () async {
+      subscription: filteredOnConfigUpdated(key).listen((event) async {
         await activate();
-        return getJson(key);
-      },
+        onConfigUpdated(getJson(key));
+      }),
     );
   }
 
   /// Returns a [RemoteParameter] of type [List] of [Map].
-  RemoteParameter<List<Map<String, Object?>>> getListJsonParameter(String key) {
+  RemoteParameter<List<Map<String, Object?>>> getListJsonParameter(
+    String key, {
+    required ValueChanged<List<Map<String, Object?>>> onConfigUpdated,
+  }) {
     return RemoteParameter<List<Map<String, Object?>>>(
       value: getListJson(key),
-      onConfigUpdated: onConfigUpdated.where(
-        (config) => config.updatedKeys.contains(key),
-      ),
-      activateAndRefetch: () async {
+      subscription: filteredOnConfigUpdated(key).listen((event) async {
         await activate();
-        return getListJson(key);
-      },
+        onConfigUpdated(getListJson(key));
+      }),
     );
   }
 
   /// Returns a [RemoteParameter] of type [T].
-  RemoteParameter<T> getDataParameter<T extends Object>({
-    required String key,
+  RemoteParameter<T> getDataParameter<T extends Object>(
+    String key, {
     required T Function(Map<String, Object?>) fromJson,
+    required ValueChanged<T> onConfigUpdated,
   }) {
     return RemoteParameter<T>(
       value: getData<T>(key: key, fromJson: fromJson),
-      onConfigUpdated: onConfigUpdated.where(
-        (config) => config.updatedKeys.contains(key),
-      ),
-      activateAndRefetch: () async {
+      subscription: filteredOnConfigUpdated(key).listen((event) async {
         await activate();
-        return getData<T>(key: key, fromJson: fromJson);
-      },
+        onConfigUpdated(getData(key: key, fromJson: fromJson));
+      }),
     );
   }
 }

--- a/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
@@ -172,7 +172,7 @@ class RemoteParameterFetcher {
   /// Returns a [RemoteParameter] of type [Map].
   RemoteParameter<Map<String, Object?>> getJsonParameter(
     String key, {
-    required void Function(Map<String, Object?> value) onConfigUpdated,
+    required ValueChanged<Map<String, Object?>> onConfigUpdated,
   }) {
     return RemoteParameter<Map<String, Object?>>(
       value: getJson(key),

--- a/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
@@ -49,10 +49,13 @@ class RemoteParameterFetcher {
   }
 
   /// Provide a Stream of updated parameter information.
+  ///
+  /// NOTE: In the method form, each call inadvertently creates
+  /// a different Stream, resulting in only the latest one being functional.
+  /// To address this issue, we use a property form to ensure a unique and
+  /// consistent Stream for each instance.
   @visibleForTesting
-  Stream<RemoteConfigUpdate> get onConfigUpdated {
-    return _rc.onConfigUpdated;
-  }
+  late final Stream<RemoteConfigUpdate> onConfigUpdated = _rc.onConfigUpdated;
 
   @visibleForTesting
   String getString(String key) {

--- a/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
+++ b/packages/flutterfire_remote_parameter_fetcher/lib/src/remote_parameter_fetcher.dart
@@ -111,7 +111,7 @@ class RemoteParameterFetcher {
         (config) => config.updatedKeys.contains(key),
       ),
       activateAndRefetch: () async {
-        await fetchAndActivate();
+        await activate();
         return getString(key);
       },
     );
@@ -125,7 +125,7 @@ class RemoteParameterFetcher {
         (config) => config.updatedKeys.contains(key),
       ),
       activateAndRefetch: () async {
-        await fetchAndActivate();
+        await activate();
         return getInt(key);
       },
     );
@@ -139,7 +139,7 @@ class RemoteParameterFetcher {
         (config) => config.updatedKeys.contains(key),
       ),
       activateAndRefetch: () async {
-        await fetchAndActivate();
+        await activate();
         return getDouble(key);
       },
     );
@@ -153,7 +153,7 @@ class RemoteParameterFetcher {
         (config) => config.updatedKeys.contains(key),
       ),
       activateAndRefetch: () async {
-        await fetchAndActivate();
+        await activate();
         return getBool(key);
       },
     );
@@ -167,7 +167,7 @@ class RemoteParameterFetcher {
         (config) => config.updatedKeys.contains(key),
       ),
       activateAndRefetch: () async {
-        await fetchAndActivate();
+        await activate();
         return getJson(key);
       },
     );
@@ -181,7 +181,7 @@ class RemoteParameterFetcher {
         (config) => config.updatedKeys.contains(key),
       ),
       activateAndRefetch: () async {
-        await fetchAndActivate();
+        await activate();
         return getListJson(key);
       },
     );
@@ -198,7 +198,7 @@ class RemoteParameterFetcher {
         (config) => config.updatedKeys.contains(key),
       ),
       activateAndRefetch: () async {
-        await fetchAndActivate();
+        await activate();
         return getData<T>(key: key, fromJson: fromJson);
       },
     );


### PR DESCRIPTION
## 🙌 What I did

<!-- What did you do in this pull request? -->

- Refactor flutterfire remote parameter fetcher
  - Made RemoteParameter more user-friendly
  - Changed to execute `activate()` instead of `fetchActivate() `during real-time retrieval
  - Updated samples and tests accordingly to the above changes

## ✍️ What I didn't do

<!-- What didn't you address in this pull request? If none, you can write "None". -->

- Rename package name

## ✅ Verification

<!-- Build and launch verification + any necessary operational checks -->

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Web

## Screenshots

<!-- If there are UI changes, attach Before and After screenshots or videos -->


https://github.com/altive/flutterfire_adapter/assets/45661924/475604a3-196c-40b4-94a0-ae057439c96b


## Additional Information

<!-- Any reference information for the reviewer (such as concerns or notes about the implementation) -->
